### PR TITLE
:hammer: Updated waiting seconds to 3 for SSL/TLS certs.

### DIFF
--- a/scripts/docker/docker-entrypoint.sh
+++ b/scripts/docker/docker-entrypoint.sh
@@ -75,7 +75,7 @@ _httpsLets()
 	# shellcheck disable=SC2046
 	while [ $(find "${NGINX_SSL_DIR}/live" -name "*.pem" | wc -l) -le 2 ]; do
 		echo "INFO: Waiting for certbot to obtain SSL/TLS files..."
-		sleep 1
+		sleep 3
 	done
 
 	if [ ! -d "/var/www/.well-known/acme-challenge" ]; then


### PR DESCRIPTION
Waiting logs were too often in NGINX.