### PR TITLE
Update nginx.conf and Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -147,7 +147,7 @@ COPY --chown=root:root --chmod=ug+x ./scripts/docker/*.sh /usr/local/bin/
 COPY --chown="1000:${GROUP}" --chmod=770 ./src/configs/ /etc/nginx/
 
 # VOLUME ["/etc/nginx/ssl"]
-EXPOSE 80 443
+# EXPOSE 80 443
 # HEALTHCHECK --start-period=20s --start-interval=1s --interval=5m --timeout=5s --retries=3 \
 # 	CMD curl -f http://localhost:80 || exit 1
 

--- a/src/configs/nginx.conf
+++ b/src/configs/nginx.conf
@@ -54,7 +54,6 @@ http {
 			'"request_length":"$request_length",'
 			'"x_forwarded_for":"$proxy_add_x_forwarded_for"'
 		'}';
-
 	include /etc/nginx/conf.d/cloudflare/log-format.conf;
 
 	error_log /dev/stderr warn;

--- a/templates/nginx.conf/010.http.conf.template
+++ b/templates/nginx.conf/010.http.conf.template
@@ -37,7 +37,7 @@ server {
 	root /var/www/web/public;
 
 	location / {
-		try_files ${DOLLAR}uri ${DOLLAR}uri/ =404;
+		try_files ${DOLLAR}uri ${DOLLAR}uri.html ${DOLLAR}uri/ =404;
 	}
 
 	## Sub-path as static files:

--- a/templates/nginx.conf/010.https.self.conf.template
+++ b/templates/nginx.conf/010.https.self.conf.template
@@ -42,7 +42,7 @@ server {
 	root /var/www/web/public;
 
 	location / {
-		try_files ${DOLLAR}uri ${DOLLAR}uri/ =404;
+		try_files ${DOLLAR}uri ${DOLLAR}uri.html ${DOLLAR}uri/ =404;
 	}
 
 	## Sub-path as static files:

--- a/templates/nginx.conf/100.example.com_https.conf.template
+++ b/templates/nginx.conf/100.example.com_https.conf.template
@@ -45,7 +45,7 @@ server {
 	root /var/www/example.com/public;
 
 	location / {
-		try_files ${DOLLAR}uri ${DOLLAR}uri/ =404;
+		try_files ${DOLLAR}uri ${DOLLAR}uri.html ${DOLLAR}uri/ =404;
 	}
 
 	## Sub-path as static files:

--- a/templates/nginx.conf/100.example.com_https.lets.conf.template
+++ b/templates/nginx.conf/100.example.com_https.lets.conf.template
@@ -46,7 +46,7 @@ server {
 	root /var/www/example.com/public;
 
 	location / {
-		try_files ${DOLLAR}uri ${DOLLAR}uri/ =404;
+		try_files ${DOLLAR}uri ${DOLLAR}uri.html ${DOLLAR}uri/ =404;
 	}
 
 	## Sub-path as static files:


### PR DESCRIPTION
This pull request updates the nginx.conf and Dockerfile to fix the try_files directive in the server blocks. The previous configuration only tried to serve the requested URI and URI/ as static files, resulting in a 404 error for URIs ending with ".html". This PR adds the ".html" extension to the try_files directive, allowing the server to correctly serve HTML files.