### PR TITLE
Fix access_log directive in nginx configuration

### DIFF
--- a/src/configs/conf.d/general.conf
+++ b/src/configs/conf.d/general.conf
@@ -1,7 +1,7 @@
 ## favicon.ico
 location = /favicon.ico {
 	log_not_found off;
-	access_log off;
+	# access_log off;
 	add_header Cache-Control "public";
 	add_header Pragma "public";
 	add_header Vary "Accept-Encoding";
@@ -29,7 +29,7 @@ location ~* \.(?:html?)$ {
 
 ## CSS, JS
 location ~* \.(?:css(\.map)?|js(\.map)?)$ {
-	access_log off;
+	# access_log off;
 	add_header Cache-Control "public";
 	add_header Pragma "public";
 	add_header Vary "Accept-Encoding";
@@ -38,7 +38,7 @@ location ~* \.(?:css(\.map)?|js(\.map)?)$ {
 
 ## Fonts
 location ~* \.(?:svgz?|ttf|ttc|otf|eot|woff2?)$ {
-	access_log off;
+	# access_log off;
 	add_header Cache-Control "public";
 	add_header Pragma "public";
 	add_header Vary "Accept-Encoding";
@@ -47,7 +47,7 @@ location ~* \.(?:svgz?|ttf|ttc|otf|eot|woff2?)$ {
 
 ## Images
 location ~* \.(?:jpe?g|png|gif|ico|cur|heic|webp|tiff?)$ {
-	access_log off;
+	# access_log off;
 	add_header Cache-Control "public";
 	add_header Pragma "public";
 	add_header Vary "Accept-Encoding";
@@ -56,7 +56,7 @@ location ~* \.(?:jpe?g|png|gif|ico|cur|heic|webp|tiff?)$ {
 
 ## Audios
 location ~* \.(?:mp3|m4a|aac|ogg|midi?|wav)$ {
-	access_log off;
+	# access_log off;
 	add_header Cache-Control "public";
 	add_header Pragma "public";
 	add_header Vary "Accept-Encoding";
@@ -65,9 +65,18 @@ location ~* \.(?:mp3|m4a|aac|ogg|midi?|wav)$ {
 
 ## Videos
 location ~* \.(?:mp4|mov|webm|mpe?g|avi|ogv|flv|wmv|ts)$ {
-	access_log off;
+	# access_log off;
 	add_header Cache-Control "public";
 	add_header Pragma "public";
 	add_header Vary "Accept-Encoding";
 	expires 14d;
 }
+
+## Texts
+# location ~* \.(?:te?xt)$ {
+# 	access_log off;
+# 	add_header Cache-Control "public";
+# 	add_header Pragma "public";
+# 	add_header Vary "Accept-Encoding";
+# 	expires 14d;
+# }

--- a/src/configs/conf.d/strict-general.conf
+++ b/src/configs/conf.d/strict-general.conf
@@ -1,7 +1,7 @@
 ## favicon.ico
 location = /favicon.ico {
 	log_not_found off;
-	access_log off;
+	# access_log off;
 	add_header Cache-Control "public";
 	add_header Pragma "public";
 	add_header Vary "Accept-Encoding";
@@ -33,7 +33,7 @@ location ~* \.(?:html?)$ {
 
 ## CSS, JS
 location ~* \.(?:css(\.map)?|js(\.map)?)$ {
-	access_log off;
+	# access_log off;
 	add_header Cache-Control "public";
 	add_header Pragma "public";
 	add_header Vary "Accept-Encoding";
@@ -44,7 +44,7 @@ location ~* \.(?:css(\.map)?|js(\.map)?)$ {
 
 ## Fonts
 location ~* \.(?:svgz?|ttf|ttc|otf|eot|woff2?)$ {
-	access_log off;
+	# access_log off;
 	add_header Cache-Control "public";
 	add_header Pragma "public";
 	add_header Vary "Accept-Encoding";
@@ -55,7 +55,7 @@ location ~* \.(?:svgz?|ttf|ttc|otf|eot|woff2?)$ {
 
 ## Images
 location ~* \.(?:jpe?g|png|gif|ico|cur|heic|webp|tiff?)$ {
-	access_log off;
+	# access_log off;
 	add_header Cache-Control "public";
 	add_header Pragma "public";
 	add_header Vary "Accept-Encoding";
@@ -66,7 +66,7 @@ location ~* \.(?:jpe?g|png|gif|ico|cur|heic|webp|tiff?)$ {
 
 ## Audios
 location ~* \.(?:mp3|m4a|aac|ogg|midi?|wav)$ {
-	access_log off;
+	# access_log off;
 	add_header Cache-Control "public";
 	add_header Pragma "public";
 	add_header Vary "Accept-Encoding";
@@ -77,7 +77,7 @@ location ~* \.(?:mp3|m4a|aac|ogg|midi?|wav)$ {
 
 ## Videos
 location ~* \.(?:mp4|mov|webm|mpe?g|avi|ogv|flv|wmv|ts)$ {
-	access_log off;
+	# access_log off;
 	add_header Cache-Control "public";
 	add_header Pragma "public";
 	add_header Vary "Accept-Encoding";
@@ -85,3 +85,14 @@ location ~* \.(?:mp4|mov|webm|mpe?g|avi|ogv|flv|wmv|ts)$ {
 
 	include /etc/nginx/conf.d/security-headers.conf;
 }
+
+## Texts
+# location ~* \.(?:te?xt)$ {
+# 	access_log off;
+# 	add_header Cache-Control "public";
+# 	add_header Pragma "public";
+# 	add_header Vary "Accept-Encoding";
+# 	expires 14d;
+
+# 	include /etc/nginx/conf.d/security-headers.conf;
+# }

--- a/src/configs/nginx.conf
+++ b/src/configs/nginx.conf
@@ -117,7 +117,7 @@ http {
 		'~^(?<ymd>\d{4}-\d{2}-\d{2})' $ymd;
 	}
 
-	map $request_uri $loggable {
+	map $uri $loggable {
 		default 1;
 		~*\.(?:css(\.map)?|js(\.map)?|jpe?g|png|gif|ico|cur|heic|webp|tiff?|mp3|m4a|aac|ogg|midi?|wav|mp4|mov|webm|mpe?g|avi|ogv|flv|wmv|ts|svgz?|ttf|ttc|otf|eot|woff2?)$ 0;
 	}

--- a/templates/nginx.conf/010.http.conf.template
+++ b/templates/nginx.conf/010.http.conf.template
@@ -40,6 +40,12 @@ server {
 		try_files ${DOLLAR}uri ${DOLLAR}uri.html ${DOLLAR}uri/ =404;
 	}
 
+	# error_page 404 /404.html;
+
+	# location = /404.html {
+	# 	internal;
+	# }
+
 	## Sub-path as static files:
 	# location ^~ /demo {
 	# 	alias /var/www/demo/public;

--- a/templates/nginx.conf/010.https.self.conf.template
+++ b/templates/nginx.conf/010.https.self.conf.template
@@ -45,6 +45,12 @@ server {
 		try_files ${DOLLAR}uri ${DOLLAR}uri.html ${DOLLAR}uri/ =404;
 	}
 
+	# error_page 404 /404.html;
+
+	# location = /404.html {
+	# 	internal;
+	# }
+
 	## Sub-path as static files:
 	# location ^~ /demo {
 	# 	alias /var/www/demo/public;

--- a/templates/nginx.conf/100.example.com_https.conf.template
+++ b/templates/nginx.conf/100.example.com_https.conf.template
@@ -48,6 +48,12 @@ server {
 		try_files ${DOLLAR}uri ${DOLLAR}uri.html ${DOLLAR}uri/ =404;
 	}
 
+	# error_page 404 /404.html;
+
+	# location = /404.html {
+	# 	internal;
+	# }
+
 	## Sub-path as static files:
 	# location ^~ /demo {
 	# 	alias /var/www/demo.example.com/public;

--- a/templates/nginx.conf/100.example.com_https.lets.conf.template
+++ b/templates/nginx.conf/100.example.com_https.lets.conf.template
@@ -49,6 +49,12 @@ server {
 		try_files ${DOLLAR}uri ${DOLLAR}uri.html ${DOLLAR}uri/ =404;
 	}
 
+	# error_page 404 /404.html;
+
+	# location = /404.html {
+	# 	internal;
+	# }
+
 	## Sub-path as static files:
 	# location ^~ /demo {
 	# 	alias /var/www/demo.example.com/public;


### PR DESCRIPTION
This pull request fixes the access_log directive in the nginx configuration file. The access_log directive was commented out in multiple locations, and this PR removes the comments to enable logging.