### PR TITLE
:bug: separate http2 directive for clarity in HTTPS server configurations

### DIFF
--- a/templates/nginx.conf/010.https.self.conf.template
+++ b/templates/nginx.conf/010.https.self.conf.template
@@ -12,8 +12,9 @@ upstream api-server {
 
 ## HTTPS:
 server {
-	listen 443 ssl http2;
-	listen [::]:443 ssl http2;
+	listen 443 ssl;
+	listen [::]:443 ssl;
+	http2 on;
 
 	## Logging:
 	access_log /dev/stdout realip_combined if=${DOLLAR}loggable;

--- a/templates/nginx.conf/100.example.com_https.conf.template
+++ b/templates/nginx.conf/100.example.com_https.conf.template
@@ -12,8 +12,9 @@ upstream api-server {
 
 # Main domain as static files (HTTPS):
 server {
-	listen 443 ssl http2;
-	listen [::]:443 ssl http2;
+	listen 443 ssl;
+	listen [::]:443 ssl;
+	http2 on;
 	server_name example.com www.example.com;
 
 	## Logging:
@@ -66,8 +67,9 @@ server {
 
 ## Subdomain as reverse proxy (HTTPS):
 server {
-	listen 443 ssl http2;
-	listen [::]:443 ssl http2;
+	listen 443 ssl;
+	listen [::]:443 ssl;
+	http2 on;
 	server_name api.example.com;
 
 	## Logging:

--- a/templates/nginx.conf/100.example.com_https.lets.conf.template
+++ b/templates/nginx.conf/100.example.com_https.lets.conf.template
@@ -12,8 +12,9 @@ upstream api-server {
 
 # Main domain as static files (HTTPS):
 server {
-	listen 443 ssl http2;
-	listen [::]:443 ssl http2;
+	listen 443 ssl;
+	listen [::]:443 ssl;
+	http2 on;
 	server_name example.com www.example.com;
 
 	## Logging:
@@ -67,8 +68,9 @@ server {
 
 ## Subdomain as reverse proxy (HTTPS):
 server {
-	listen 443 ssl http2;
-	listen [::]:443 ssl http2;
+	listen 443 ssl;
+	listen [::]:443 ssl;
+	http2 on;
 	server_name api.example.com;
 
 	## Logging:


### PR DESCRIPTION
This pull request modifies several Nginx configuration templates to adjust the handling of HTTP/2 by separating the `http2` directive from the `listen` directive. The changes ensure that HTTP/2 is explicitly enabled using the `http2 on;` directive instead of being coupled with the `listen` directive.

### Changes to Nginx configuration templates:

* [`templates/nginx.conf/010.https.self.conf.template`](diffhunk://#diff-46c28b89dff96a909b792506fe03ff99314fbd7035f5142b0f7eb582f3e22138L15-R17): Updated the `server` block to replace `listen ... http2` with `listen ... ssl` and added the `http2 on;` directive.
* `templates/nginx.conf/100.example.com_https.conf.template`:
  - Updated the `server` block for the main domain to replace `listen ... http2` with `listen ... ssl` and added the `http2 on;` directive.
  - Updated the `server` block for the subdomain to replace `listen ... http2` with `listen ... ssl` and added the `http2 on;` directive.
* `templates/nginx.conf/100.example.com_https.lets.conf.template`:
  - Updated the `server` block for the main domain to replace `listen ... http2` with `listen ... ssl` and added the `http2 on;` directive.
  - Updated the `server` block for the subdomain to replace `listen ... http2` with `listen ... ssl` and added the `http2 on;` directive.