### PR TITLE
fix: ensure proper exit status handling in nginx-reload script

### DIFF
--- a/scripts/docker/nginx-reload.sh
+++ b/scripts/docker/nginx-reload.sh
@@ -12,3 +12,5 @@ fi
 
 echo -e "reloaded_dtime: $(date "+%Y-%m-%dT%H:%M:%S%z")" >> /var/log/nginx/nginx_reload.log || exit 2
 echo -e "SUCCESS: Done.\n"
+
+exit 0


### PR DESCRIPTION
This pull request includes a minor change to the `scripts/docker/nginx-reload.sh` file. The change ensures the script explicitly exits with a success code (`exit 0`) after completing its operations.