### PR TITLE
:hammer: standardize log messages in nginx entrypoint and reload scri…

### DIFF
--- a/scripts/docker/nginx-reload.sh
+++ b/scripts/docker/nginx-reload.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 
-echo "INFO: Running nginx-reload.sh..."
+echo "[INFO]: Running nginx-reload.sh..."
 sleep 2
 nginx -s reload || exit 2
 
@@ -11,6 +11,6 @@ if [ ! -d "/var/log/nginx" ]; then
 fi
 
 echo -e "reloaded_dtime: $(date "+%Y-%m-%dT%H:%M:%S%z")" >> /var/log/nginx/nginx_reload.log || exit 2
-echo -e "SUCCESS: Done.\n"
+echo -e "[OK]: Done.\n"
 
 exit 0


### PR DESCRIPTION
This pull request standardizes the logging format in the `scripts/docker` directory by introducing a consistent `[INFO]`, `[OK]`, and `[ERROR]` prefix format for log messages. The changes improve clarity and uniformity across the scripts.

### Logging Standardization:

* Updated log messages in `scripts/docker/docker-entrypoint.sh` to use `[INFO]` for informational messages, `[OK]` for success messages, and `[ERROR]` for error messages. Examples include messages for starting services, generating SSL files, and handling permissions. [[1]](diffhunk://#diff-7a315433483d81b315677778f83bef7a5c0d7b60b65a15a8f99f3d3890873f39L5-R5) [[2]](diffhunk://#diff-7a315433483d81b315677778f83bef7a5c0d7b60b65a15a8f99f3d3890873f39L17-R21) [[3]](diffhunk://#diff-7a315433483d81b315677778f83bef7a5c0d7b60b65a15a8f99f3d3890873f39L31-R44) [[4]](diffhunk://#diff-7a315433483d81b315677778f83bef7a5c0d7b60b65a15a8f99f3d3890873f39L63-R63) [[5]](diffhunk://#diff-7a315433483d81b315677778f83bef7a5c0d7b60b65a15a8f99f3d3890873f39L76-R76) [[6]](diffhunk://#diff-7a315433483d81b315677778f83bef7a5c0d7b60b65a15a8f99f3d3890873f39L90-R92) [[7]](diffhunk://#diff-7a315433483d81b315677778f83bef7a5c0d7b60b65a15a8f99f3d3890873f39L102-R106) [[8]](diffhunk://#diff-7a315433483d81b315677778f83bef7a5c0d7b60b65a15a8f99f3d3890873f39L127-R134) [[9]](diffhunk://#diff-7a315433483d81b315677778f83bef7a5c0d7b60b65a15a8f99f3d3890873f39L144-R144) [[10]](diffhunk://#diff-7a315433483d81b315677778f83bef7a5c0d7b60b65a15a8f99f3d3890873f39L167-R176)

* Updated `scripts/docker/nginx-reload.sh` to match the new logging format with `[INFO]` and `[OK]` prefixes for its output. [[1]](diffhunk://#diff-feb8346f0e2bfebe1b2c639ad8fceef01a389259ddf9b506bfd9d80fe5624175L5-R5) [[2]](diffhunk://#diff-feb8346f0e2bfebe1b2c639ad8fceef01a389259ddf9b506bfd9d80fe5624175L14-R14)