### PR TITLE
:wrench: Add custom error pages for 444 and 499 status codes and upda…

### DIFF
--- a/src/configs/conf.d/error-pages.conf
+++ b/src/configs/conf.d/error-pages.conf
@@ -46,6 +46,18 @@ location = /custom/429.html {
 	internal;
 }
 
+error_page 444 /custom/444.html;
+location = /custom/444.html {
+	root /usr/share/nginx/html;
+	internal;
+}
+
+error_page 499 /custom/499.html;
+location = /custom/499.html {
+	root /usr/share/nginx/html;
+	internal;
+}
+
 error_page 500 /custom/500.html;
 location = /custom/500.html {
 	root /usr/share/nginx/html;

--- a/src/configs/nginx.conf
+++ b/src/configs/nginx.conf
@@ -21,7 +21,7 @@ http {
 	server_tokens off;
 	log_not_found off;
 	types_hash_max_size 2048;	# Default: 1024
-	client_max_body_size 25m;	# Default: 1m
+	client_max_body_size 100m;	# Default: 1m
 
 
 	## MIME types:

--- a/src/html/custom/444.html
+++ b/src/html/custom/444.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+	<meta charset="UTF-8" />
+	<meta http-equiv="X-UA-Compatible" content="IE=edge" />
+	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+	<title>444 Error Page</title>
+	<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+
+<body>
+	<div class="d-flex align-items-center justify-content-center vh-100">
+		<div class="text-center">
+			<h1 class="display-1 fw-bold">444</h1>
+			<p class="fs-3">
+				<span class="text-danger">Connection Closed</span> by Server.
+			</p>
+			<p class="lead">
+				The server has closed the connection without sending any response.
+			</p>
+		</div>
+	</div>
+</body>
+
+</html>

--- a/src/html/custom/499.html
+++ b/src/html/custom/499.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+	<meta charset="UTF-8" />
+	<meta http-equiv="X-UA-Compatible" content="IE=edge" />
+	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+	<title>499 Error Page</title>
+	<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+
+<body>
+	<div class="d-flex align-items-center justify-content-center vh-100">
+		<div class="text-center">
+			<h1 class="display-1 fw-bold">499</h1>
+			<p class="fs-3">
+				<span class="text-warning">Client Closed Request</span>
+			</p>
+			<p class="lead">
+				The client closed the connection before the server could respond.
+			</p>
+		</div>
+	</div>
+</body>
+
+</html>

--- a/templates/compose/compose.override.prod.yml
+++ b/templates/compose/compose.override.prod.yml
@@ -2,6 +2,7 @@ services:
   nginx:
     image: bybatkhuu/nginx:3.0.4-250526
     # volumes:
+    #   - "./volumes/storage/nginx/configs/nginx.conf:/etc/nginx/nginx.conf"
     #   - "./volumes/storage/nginx/ssl:/etc/nginx/ssl"
     # deploy:
     #   replicas: 0

--- a/templates/nginx.conf/100.example.com_https.lets.conf.template
+++ b/templates/nginx.conf/100.example.com_https.lets.conf.template
@@ -30,7 +30,7 @@ server {
 
 	## SSL:
 	include /etc/nginx/conf.d/ssl.conf;
-	ssl_stapling on;
+	ssl_stapling off;
 	ssl_certificate /etc/nginx/ssl/live/example.com/fullchain.pem;
 	ssl_certificate_key /etc/nginx/ssl/live/example.com/privkey.pem;
 	ssl_trusted_certificate /etc/nginx/ssl/live/example.com/chain.pem;


### PR DESCRIPTION
This pull request introduces several updates to the NGINX configuration, including new custom error pages, increased client body size limits, and changes to SSL settings. Below is a summary of the most important changes grouped by theme.

### Custom Error Pages:
* Added new custom error pages for HTTP status codes `444` and `499` in `src/configs/conf.d/error-pages.conf`. These pages are served internally and reference new HTML files.
* Created `src/html/custom/444.html` with a Bootstrap-styled page explaining the "Connection Closed by Server" error.
* Created `src/html/custom/499.html` with a Bootstrap-styled page explaining the "Client Closed Request" error.

### Configuration Enhancements:
* Increased `client_max_body_size` from `25m` to `100m` in `src/configs/nginx.conf` to allow larger client request payloads.

### SSL Configuration:
* Disabled `ssl_stapling` in `templates/nginx.conf/100.example.com_https.lets.conf.template`, likely for compatibility or troubleshooting purposes.

### Miscellaneous:
* Added commented-out volume mapping for `nginx.conf` in `templates/compose/compose.override.prod.yml`, potentially for easier local configuration overrides.