### PR TITLE
:green_heart: Refactor GITHUB_TOKEN usage in create-release workflow …

### DIFF
--- a/.github/workflows/3.create-release.yml
+++ b/.github/workflows/3.create-release.yml
@@ -19,22 +19,17 @@ jobs:
     permissions:
       contents: write
       actions: write
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Create release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release create v$(./scripts/get-version.sh) --generate-notes
       - name: Check Workflow
-        id: check_workflow
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           _WORKFLOW_STATE=$(gh api repos/$(gh repo view --json nameWithOwner -q .nameWithOwner)/actions/workflows/4.update-changelog.yml | jq -r '.state')
           echo "_WORKFLOW_STATE=${_WORKFLOW_STATE}" >> ${GITHUB_ENV}
       - name: Trigger Changelog
         if: ${{ env._WORKFLOW_STATE == 'active' }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh workflow run 4.update-changelog.yml


### PR DESCRIPTION
This pull request simplifies the configuration of environment variables in the `.github/workflows/3.create-release.yml` file by consolidating the `GITHUB_TOKEN` definition under the `env` key at the job level.

Workflow configuration changes:

* [`.github/workflows/3.create-release.yml`](diffhunk://#diff-43f0f5a64fe03df7574739bee10c527b7c8eb810f87b37a78e4cb012eec0425dR22-L39): Moved the `GITHUB_TOKEN` environment variable definition from individual steps to the job-level `env` block for better maintainability and reduced redundancy.