### PR TITLE
fix: update base image to Ubuntu 26.04 and bump NGINX version to 1.30.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
 # syntax=docker/dockerfile:1
 
-ARG BASE_IMAGE=ubuntu:24.04
+# ARG BASE_IMAGE=ubuntu:24.04
+ARG BASE_IMAGE=ubuntu:26.04
 
 ARG DEBIAN_FRONTEND=noninteractive
-ARG NGINX_VERSION=1.28.0
+ARG NGINX_VERSION=1.30.1
 
 
 # Here is the builder image
@@ -24,8 +25,9 @@ RUN rm -rfv /var/lib/apt/lists/* /var/cache/apt/archives/* /tmp/* /root/.cache/*
 		build-essential \
 		wget \
 		tar \
-		libpcre3 \
-		libpcre3-dev \
+		# libpcre3 \
+		# libpcre3-dev \
+		libpcre2-dev \
 		zlib1g \
 		zlib1g-dev \
 		libssl-dev \
@@ -58,6 +60,7 @@ RUN wget -nv --show-progress --progress=bar:force:noscroll "https://nginx.org/do
 		--with-http_realip_module \
 		--with-http_auth_request_module \
 		--with-http_v2_module \
+		--with-http_v3_module \
 		--with-http_slice_module \
 		--with-threads \
 		--with-http_addition_module \
@@ -67,7 +70,7 @@ RUN wget -nv --show-progress --progress=bar:force:noscroll "https://nginx.org/do
 		--with-stream \
 		--with-stream_ssl_module \
 		--with-http_mp4_module \
-		--with-http_geoip_module \
+		--with-http_geoip_module=dynamic \
 		--without-mail_pop3_module \
 		--without-mail_imap_module \
 		--without-mail_smtp_module && \


### PR DESCRIPTION
This pull request updates the `Dockerfile` to use newer base images and dependencies, as well as to enable additional NGINX features. The main changes focus on modernizing the build environment, updating NGINX to a newer version, and adjusting the build configuration for improved protocol support and compatibility.

**Base image and dependency updates:**
- Switched the base image from `ubuntu:24.04` to `ubuntu:26.04` to use a more recent Ubuntu release.
- Updated the NGINX version from `1.28.0` to `1.30.1`.
- Replaced `libpcre3` and `libpcre3-dev` with `libpcre2-dev` to use the newer PCRE2 library.

**NGINX build configuration improvements:**
- Added the `--with-http_v3_module` flag to enable HTTP/3 support in NGINX.
- Changed the `--with-http_geoip_module` flag to `--with-http_geoip_module=dynamic` to build the GeoIP module as a dynamic module instead of statically.